### PR TITLE
Agrega guía de estilo para Shell

### DIFF
--- a/ciencia_de_datos/guia_de_estilo/estructura.md
+++ b/ciencia_de_datos/guia_de_estilo/estructura.md
@@ -2,31 +2,53 @@
 layout: page
 title: Estructura de los directorios
 tagline: Guía de estilo
-description: Este documento extiende las guías de estilo adoptadas por el equipo de Ciencia de Datos de GECI
+description: Guía de estilo para la estructura de los directorios del equipo de Ciencia de Datos de GECI
 ---
 
-Aquí se define la estructura requerida en las carpetas de trabajo.
+Aquí se define la estructura requerida en los repositorios clase 3. Todavía no tenemos una guía para los repositorios clase 1 o de otra clase.
 
-En la raíz de la carpeta de trabajo se encuentran los archivos:
+La estructura que aquí se describe está inspirada en [Cookiecutter Data Science](https://drivendata.github.io/cookiecutter-data-science/#directory-structure). Antes de modificar nuestra guía primero debemos consultar aquella para intentar no contradecirla.
 
-- `Makefile`
-- `README.md`
-
-Además, se encuentran directorios que contienen:
-
-| Carpeta                  | R                | MATLAB                  |
-|--------------------------|------------------|-------------------------|
-| Funciones                | `R/`             | `MATLAB/funciones`      |
-| Clases                   | `R/`             | `MATLAB/clases`         |
-| Demostraciones           | `vignettes/`     | `MATLAB/demostraciones` |
-| Pruebas                  | `tests/`         | `tests/`                |
-| Datos en formato nativo  | `data/*.RData`   | `data/*.mat`            |
-| Datos en otro formato    | `inst/extdata/`  | `inst/extdata/`         |
-| Programas                | `R/`             | `MATLAB/programas`      |
-| Resultados               | `resultados/`    | `resultados/`           |
-| Entrega                  | `entrega/`       | `entrega/`              |
-| Referencias              | `referencias/`   | `referencias/`          |
-
+```
+├── Dockerfile         <- Por lo general nuestros Dockerfiles son de una única línea con el
+│                         comando `FROM`
+├── Makefile           <- Makefile para ejecutar cosas como `make reporte` o `make resultados`
+├── README.md          <- Contiene una lista ordenada de los resultados esperados (_backlog_)
+│                         del proyecto y es la única fuente que indica el trabajo requerido
+├── data/
+│   ├── external/      <- Datos de terceros
+│   ├── processed/     <- Datos procesados para que tengan la forma requerida por los módulos
+│   │                     y paquetes para análisis estadísticos y modelación. También
+│   │                     resultados parciales que no se incluyen directamente en el reporte
+│   │                     como archivos KML y SHP.
+│   └── raw/           <- Los datos crudos originales e inmutables de GECI
+│
+├── docs/              <- Documentación para los analistas
+├── notebooks/         <- Notebooks de Jupyter
+├── references/        <- Artículos, libros y notas que son relevantes para el proyecto y para
+│   │                     los resultados que estamos produciendo. Aquí se encuentran los
+│   │                     artículos que se citan en los reportes que producimos
+│   ├── references.bib <- Archivo de referecias para LaTeX en formato BibTeX
+|   └── references.md  <- Lista de referencias con una descripción e hipervínculos en Markdown
+│
+├── renv.lock          <- Registro de los paquetes instalados en R y sus versiones. Este
+│                         archivo es generado con el paquete `renv` y es equivalente al
+│                         archivo `requirements.txt` generado con `pip freeze`
+├── reports/           <- Reportes y presentaciones dirigidos al director de proyecto
+│   │                     correspondiente. Los formatos preferidos para el código fuente de
+│   │                     los reportes son LaTeX y Markdown. Se prefieren formatos de texto
+│   │                     plano para poder implementar control de versiones. El reporte se
+│   │                     entrega en formato PDF o, si el Director lo requiere, se usa Pandoc
+│   │                     para transformar a Word.
+│   ├── figures/       <- Figuras incluidas en los reportes de los análisis realizados
+|   └── tables/        <- Tablas incluidas en los reportes de los análisis realizados
+│
+├── requirements.txt   <- Enlista los requerimientos para obtener el entorno para realizar el
+│                         análisis, por ejemplo puede ser generado con:
+│                         `pip freeze > requirements.txt`
+├── src/               <- Scripts que se usarán en este proyecto
+└── tests/             <- Pruebas que verifican la repoducibilidad de los resultados
+```
 
 ## `Makefile`
 

--- a/ciencia_de_datos/guia_de_estilo/estructura.md
+++ b/ciencia_de_datos/guia_de_estilo/estructura.md
@@ -5,16 +5,18 @@ tagline: Guía de estilo
 description: Guía de estilo para la estructura de los directorios del equipo de Ciencia de Datos de GECI
 ---
 
-Aquí se define la estructura requerida en los repositorios clase 3. Todavía no tenemos una guía para los repositorios clase 1 o de otra clase.
+En esta página definimos la estructura requerida en los repositorios clase 3. Todavía no tenemos una guía para los repositorios clase 1 o de otra clase.
 
-La estructura que aquí se describe está inspirada en [Cookiecutter Data Science](https://drivendata.github.io/cookiecutter-data-science/#directory-structure). Antes de modificar nuestra guía primero debemos consultar aquella para intentar no contradecirla.
+La estructura que aquí describimos está inspirada en [Cookiecutter Data Science](https://drivendata.github.io/cookiecutter-data-science/#directory-structure). Antes de modificar nuestra guía primero debemos consultar aquella para intentar no contradecirla.
 
 ```
-├── Dockerfile         <- Por lo general nuestros Dockerfiles son de una única línea con el
-│                         comando `FROM`
+├── Dockerfile         <- Especifica la imagen padre del repo, por ejemplo:
+│                         `FROM islasgeci/base:2d95`
 ├── Makefile           <- Makefile para ejecutar cosas como `make reporte` o `make resultados`
 ├── README.md          <- Contiene una lista ordenada de los resultados esperados (_backlog_)
 │                         del proyecto y es la única fuente que indica el trabajo requerido
+├── analyses.json      <- Describe las relaciones entre los archivos (datos, reportes,
+│                         resultados, scripts, etc.) de cada análisis
 ├── data/
 │   ├── external/      <- Datos de terceros
 │   ├── processed/     <- Datos procesados para que tengan la forma requerida por los módulos
@@ -41,6 +43,7 @@ La estructura que aquí se describe está inspirada en [Cookiecutter Data Scienc
 │   │                     entrega en formato PDF o, si el Director lo requiere, se usa Pandoc
 │   │                     para transformar a Word.
 │   ├── figures/       <- Figuras incluidas en los reportes de los análisis realizados
+│   ├── non-tabular/   <- Resultados incluidos en los reportes de los análisis realizados
 |   └── tables/        <- Tablas incluidas en los reportes de los análisis realizados
 │
 ├── requirements.txt   <- Enlista los requerimientos para obtener el entorno para realizar el

--- a/ciencia_de_datos/guia_de_estilo/introduccion.md
+++ b/ciencia_de_datos/guia_de_estilo/introduccion.md
@@ -11,6 +11,7 @@ El equipo de Ciencia de datos en GECI adopta las siguientes guías de estilo:
 - [HTML y CSS](https://google.github.io/styleguide/htmlcssguide.html)
 - [Python](https://www.python.org/dev/peps/pep-0008)
 - [R](https://google.github.io/styleguide/Rguide.xml)
+- [Shell](https://google.github.io/styleguide/shell.xml)
 - [Tipografía](https://physics.nist.gov/cuu/pdf/typefaces.pdf)
 
 Las guías de estilo anteriores no son exhaustivas y este documento las extiende. Esta guía de estilo es válida sólo en los casos no contemplados en las guías de estilo anteriores. En caso de conflicto, las guías de estilo anteriores tienen preferencia sobre ésta.

--- a/ciencia_de_datos/guia_de_estilo/introduccion.md
+++ b/ciencia_de_datos/guia_de_estilo/introduccion.md
@@ -7,8 +7,8 @@ description: Este documento extiende las guías de estilo adoptadas por el equip
 
 El equipo de Ciencia de datos en GECI adopta las siguientes guías de estilo:
 
+- [Estructura de directorios](https://drivendata.github.io/cookiecutter-data-science)
 - [HTML y CSS](https://google.github.io/styleguide/htmlcssguide.html)
-- [MATLAB](http://www.datatool.com/downloads/MatlabStyle2%20book.pdf)
 - [Python](https://www.python.org/dev/peps/pep-0008)
 - [R](https://google.github.io/styleguide/Rguide.xml)
 - [Tipografía](https://physics.nist.gov/cuu/pdf/typefaces.pdf)


### PR DESCRIPTION
Propongo que usemos la guía de estilo de Google para Shell.
@jdavidmacer ya me aprobó pasar esto a `develop`, me gustaría que alguien más me permita pasarlo a `master` para que aparezca publicado [aquí](https://islasgeci.github.io/ciencia_de_datos/guia_de_estilo/introduccion.html).