### PR TITLE
Cambia referencia de la guia de estilo para R

### DIFF
--- a/ciencia_de_datos/guia_de_estilo/introduccion.md
+++ b/ciencia_de_datos/guia_de_estilo/introduccion.md
@@ -10,7 +10,7 @@ El equipo de Ciencia de datos en GECI adopta las siguientes guías de estilo:
 - [Estructura de directorios](https://drivendata.github.io/cookiecutter-data-science)
 - [HTML y CSS](https://google.github.io/styleguide/htmlcssguide.html)
 - [Python](https://www.python.org/dev/peps/pep-0008)
-- [R](https://google.github.io/styleguide/Rguide.xml)
+- [R](https://style.tidyverse.org/)
 - [Shell](https://google.github.io/styleguide/shell.xml)
 - [Tipografía](https://physics.nist.gov/cuu/pdf/typefaces.pdf)
 - [SQL](https://about.gitlab.com/handbook/business-ops/data-team/sql-style-guide/#sql-style-guide)


### PR DESCRIPTION
La guia anterior no era congruente para definir variables y hacia falta mas detalles de estilo.