### PR TITLE
Agrega instrucciones para servir página localmente para su revisión

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,3 +1,15 @@
 ## Ciencia de Datos en Conservación de Islas
 
 Este repositorio es la fuente de la página del equipo de [Ciencia de Datos](https://github.com/IslasGECI) del [Grupo de Ecología y Conservación de Islas](https://islas.org.mx).
+
+Para servir esta página localmente con Docker ejecuta:
+
+```
+docker run \
+    --publish 4000:4000 \
+    --rm \
+    --volume="${PWD}:/srv/jekyll" \
+    jekyll/jekyll:4 jekyll serve
+```
+
+y visita [localhost:4000](http://localhost:4000).

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -12,6 +12,8 @@ Islas](https://islas.org.mx).
     - [Crear
       cuenta](https://join.slack.com/t/islasgeci/shared_invite/zt-f8kqlr2t-C8dO0JthMxaT81ShJiNk0w)
 
+---
+
 Para servir esta página localmente con Docker ejecuta:
 
 ```


### PR DESCRIPTION
Ha sido difícil revisar está página porque no hemos podido verificar cómo se ve el contenido renderizado sino hasta que hacemos _merge_ hacia la `master`. En este _pull request_ agregué las instrucciones al `READEME` para servir la página localmente y así verificar como se verá una vez que lo aceptemos.