### PR TITLE
💬 Add blogpost about an error in devcontainer

### DIFF
--- a/_posts/2022-03-08-devcontainer_workdir.md
+++ b/_posts/2022-03-08-devcontainer_workdir.md
@@ -5,28 +5,25 @@ author: Francisco Alejandro Padilla Gomez
 tags: equipo
 ---
 
-Al querer configurar VS Code para trabajar, se necesita realizar instalación de una extencion
-previa. Se instalará `Remote - Containers`. Esta permite abrir cualquier repositorio dentro de un
-contenedor de Docker.
+Cuando configuramos VS Code para trabajar, necesitamos realizar instalación de una extencion previa.
+Instalaremos _Remote Development_ `ms-vscode-remote.vscode-remote-extensionpack`. Esta permite abrir
+cualquier repositorio dentro de un contenedor de Docker.
 
-Después de que se terminó de instalar, se le dará clic en un botón verde encontrado en la parte
-inferior izquierda. Se encontrarán varías opciones, entonces se seleccionará `open container`.
+Después de que terminamos de instalar, le damos clic en un botón verde encontrado en la parte
+inferior izquierda. Se encontrarán varías opciones, entonces seleccionamos `open container`.
 
 Al estar dentro del contenedor, entonces ya podremos realizar cambios, correr scripts, etc. Al
 ejecutar recipes del Makefile pueden surgir errores al no tener bien definido el directorio de
 trabajo. 
 
-Cuando tengamos errores donde se tiene `[Makefile:45: data/processed/logistic_model_table.csv] Error 1` es probable que nuestra carpeta de trabajo y nuestra carpeta local no estén vinculadas. Para
+Cuando tengamos errores donde tenemos `[Makefile:45: data/processed/logistic_model_table.csv] Error
+1` es probable que nuestra carpeta de trabajo y nuestra carpeta local no estén vinculadas. Para
 vincularlas tendremos que modificar el archivo `.devcontainer/devcontainer.json`.
-```bash
-/workspaces/repositorio
-```
 
 Dentro de `.devcontainer/devcontainer.json` agregaremos:
 
 ```json
 "workspaceMount": "source=${localWorkspaceFolder},target=/workdir,type=bind",
-
 "workspaceFolder": "/workdir"
 ```
 
@@ -34,8 +31,8 @@ Con la opción `workspaceMount` le decimos al VS Code que vincule nuestro direct
 carpeta `/workdir/`. Y con la opción `workspaceFolder` definimos la carpeta de trabajo.
 
 Ahora tenemos que borrar los contenedores porque puede ser que VS Code los vuelva a utilizar al
-reconstruir el contenedor. Así que borraremos dichos contenedores desde una terminal fuera de
-VS Code.
+reconstruir el contenedor. Así que borraremos dichos contenedores desde una terminal fuera de VS
+Code.
 
 Primero veremos los procesos con:
 
@@ -65,3 +62,4 @@ El subcomando `docker rm` remueve los contenedores.
 
 Ya habiendo realizado esto, podemos volver a abrir el contenedor en VS Code y estará resuelto el
 problema: nuestro directorio de trabajo será `/workdir/`
+

--- a/_posts/2022-03-08-devcontainer_workdir.md
+++ b/_posts/2022-03-08-devcontainer_workdir.md
@@ -1,12 +1,23 @@
 ---
 layout: post
-title: Devcontainer and workdir
+title: "Iniciando con VS Code y error en Devcontainer"
 author: Francisco Alejandro Padilla Gomez
 tags: equipo
 ---
-Cuando tengamos errores del tipo _missing file_ es probable que nuestra carpeta de trabajo y nuestra
-carpeta local no estén vinculadas. Para vincularlas tendremos que modificar el archivo
-`.devcontainer/devcontainer.json`.
+
+Al querer configurar VS Code para trabajar, se necesita realizar instalación de una extencion
+previa. Se instalará `Remote - Containers`. Esta permite abrir cualquier repositorio dentro de un
+contenedor de Docker.
+
+Después de que se terminó de instalar, se le dará clic en un botón verde encontrado en la parte
+inferior izquierda. Se encontrarán varías opciones, entonces se seleccionará `open container`.
+
+Al estar dentro del contenedor, entonces ya podremos realizar cambios, correr scripts, etc. Al
+ejecutar recipes del Makefile pueden surgir errores al no tener bien definido el directorio de
+trabajo. 
+
+Cuando tengamos errores donde se tiene `[Makefile:45: data/processed/logistic_model_table.csv] Error 1` es probable que nuestra carpeta de trabajo y nuestra carpeta local no estén vinculadas. Para
+vincularlas tendremos que modificar el archivo `.devcontainer/devcontainer.json`.
 ```bash
 /workspaces/repositorio
 ```

--- a/_posts/2022-03-08-devcontainer_workdir.md
+++ b/_posts/2022-03-08-devcontainer_workdir.md
@@ -4,18 +4,23 @@ title: Devcontainer and workdir
 author: Francisco Alejandro Padilla Gomez
 tags: equipo
 ---
+
 Cuando tengamos errores del tipo _missing file_ es probable que nuestra carpeta de trabajo y nuestra
 carpeta local no estén vinculadas. Para vincularlas tendremos que modificar el archivo
 `.devcontainer/devcontainer.json`.
-```bash
+
+```
 /workspaces/repositorio
 ```
+
 Dentro de `.devcontainer/devcontainer.json` agregaremos:
+
 ```json
 "workspaceMount": "source=${localWorkspaceFolder},target=/workdir,type=bind",
 
 "workspaceFolder": "/workdir"
 ```
+
 Con la opción `workspaceMount` le decimos al VS Code que vincule nuestro directorio local en la
 carpeta workdir. Y con la opción `workspaceFolder` definimos la carpeta de trabajo.
 
@@ -24,22 +29,28 @@ reconstruir el contenedor. Así que borraremos dichos contenedores desde una ter
 VS Code.
 
 Primero veremos los procesos con
+
 ```shell
 $ docker ps -all
 ```
+
 La opción `-all` nos muestra todos los contenedores.
 
 La instrucción anterior nos muestra el id del contenedor, la imagen con el que generamos el
 contenedor, el comando actual y otras columnas.
 
 Para ver solo el id de dichos procesos utilizamos 
+
 ```shell
 $ docker ps --all --quiet
 ```
+
 Ahora, para borrar todos, utilizaremos la siguiente función con argumento el comando anterior.
+
 ```shell
 $ docker rm $(docker ps --all --quiet)
 ```
+
 El subcomando `docker rm` remueve los contenedores.
 
 Ya habiendo realizado esto, puedes volver a abrir el contenedor en VS Code y estará resuelto el

--- a/_posts/2022-03-08-devcontainer_workdir.md
+++ b/_posts/2022-03-08-devcontainer_workdir.md
@@ -5,16 +5,17 @@ author: Francisco Alejandro Padilla Gomez
 tags: equipo
 ---
 
-Cuando configuramos VS Code para trabajar, necesitamos realizar instalación de una extencion previa.
-Instalaremos _Remote Development_ `ms-vscode-remote.vscode-remote-extensionpack`. Esta permite abrir
-cualquier repositorio dentro de un contenedor de Docker.
+Cuando configuramos VS Code para trabajar, necesitamos instalar una extencion previa. Instalaremos
+_Remote Development_ `ms-vscode-remote.vscode-remote-extensionpack`. Esta extensión nos permite
+abrir cualquier repositorio dentro de un contenedor de Docker.
 
-Después de que terminamos de instalar, le damos clic en un botón verde encontrado en la parte
-inferior izquierda. Se encontrarán varías opciones, entonces seleccionamos `open container`.
+Después de que terminamos de instalar _Remote Development_, le damos clic en un botón verde
+encontrado en la parte inferior izquierda. Encontramos varías opciones, entonces seleccionamos `open
+container`.
 
 Al estar dentro del contenedor, entonces ya podremos realizar cambios, correr scripts, etc. Al
 ejecutar recipes del Makefile pueden surgir errores al no tener bien definido el directorio de
-trabajo. 
+trabajo.
 
 Cuando tengamos errores donde tenemos `[Makefile:45: data/processed/logistic_model_table.csv] Error
 1` es probable que nuestra carpeta de trabajo y nuestra carpeta local no estén vinculadas. Para

--- a/_posts/2022-03-08-devcontainer_workdir.md
+++ b/_posts/2022-03-08-devcontainer_workdir.md
@@ -4,38 +4,43 @@ title: Devcontainer and workdir
 author: Francisco Alejandro Padilla Gomez
 tags: equipo
 ---
-Cuando se tienen errores del tipo un cierto archivo no se encuentra en
+Cuando tengamos errores del tipo _missing file_ es probable que nuestra carpeta de trabajo y nuestra
+carpeta local no estén vinculadas. Para vincularlas tendremos que modificar el archivo
+**devcontainer**.
 ```bash
 /workspaces/sub-folder
 ```
-Entonces dentro de **.devcontainer/devcontainer.json** se tiene que agregar:
+Dentro de **.devcontainer/devcontainer.json** agregaremos:
 ```bash
 "workspaceMount": "source=${localWorkspaceFolder},target=/workdir,type=bind",
 
 "workspaceFolder": "/workdir"
 ```
-Ahora, se tienen que borrar los contenedores porque puede que vscode los vuelva a utilizar al
-reconstruir el contenedor, así que borraremos dichos contenedores desde una terminal fuera de
+Con la opción `workspaceMount` le decimos al vscode que vincule nuestro directorio local en la
+carpeta workdir. Y con la opción `workspaceFolder` definimos la carpeta de trabajo.
+
+Ahora tenemos que borrar los contenedores porque puede que vscode los vuelva a utilizar al
+reconstruir el contenedor. Así que borraremos dichos contenedores desde una terminal fuera de
 vscode.
 
-Primero se ven los procesos con
-```bash
+Primero veremos los procesos con
+```
 $ docker ps -a
 ```
-La opción -a nos muestra todos los contenedores.
+La opción `-a` nos muestra todos los contenedores.
 
-La instrucción anterior nos muestra el id del contenedor, la imagen con el que se generó el
+La instrucción anterior nos muestra el id del contenedor, la imagen con el que generamos el
 contenedor, el comando actual y otras columnas.
 
 Para ver solo el id de dichos procesos utilizamos 
-```bash
+```
 $ docker ps -aq
 ```
-Ahora, para borrar todos, podemos utilizar la siguiente función con argumento el comando anterior.
+Ahora, para borrar todos, utilizaremos la siguiente función con argumento el comando anterior.
 ```bash
 $ docker rm $(docker ps -aq)
 ```
-El comando rm remueve los contenedores.
+La instrucción `rm` remueve los contenedores.
 
-Ya habiendo realizado esto, puedes volcer a abrir el contenedor en vscode y tendría que ya estar
-resuelto el problema, estando automaticamente en **/workdir**
+Ya habiendo realizado esto, puedes volver a abrir el contenedor en vscode y estará resuelto el
+problema: nuestro directorio de trabajo será **/workdir**

--- a/_posts/2022-03-08-devcontainer_workdir.md
+++ b/_posts/2022-03-08-devcontainer_workdir.md
@@ -6,41 +6,41 @@ tags: equipo
 ---
 Cuando tengamos errores del tipo _missing file_ es probable que nuestra carpeta de trabajo y nuestra
 carpeta local no estén vinculadas. Para vincularlas tendremos que modificar el archivo
-**devcontainer**.
+`.devcontainer/devcontainer.json`.
 ```bash
-/workspaces/sub-folder
+/workspaces/repositorio
 ```
-Dentro de **.devcontainer/devcontainer.json** agregaremos:
-```bash
+Dentro de `.devcontainer/devcontainer.json` agregaremos:
+```json
 "workspaceMount": "source=${localWorkspaceFolder},target=/workdir,type=bind",
 
 "workspaceFolder": "/workdir"
 ```
-Con la opción `workspaceMount` le decimos al vscode que vincule nuestro directorio local en la
+Con la opción `workspaceMount` le decimos al VS Code que vincule nuestro directorio local en la
 carpeta workdir. Y con la opción `workspaceFolder` definimos la carpeta de trabajo.
 
 Ahora tenemos que borrar los contenedores porque puede que vscode los vuelva a utilizar al
 reconstruir el contenedor. Así que borraremos dichos contenedores desde una terminal fuera de
-vscode.
+VS Code.
 
 Primero veremos los procesos con
+```shell
+$ docker ps -all
 ```
-$ docker ps -a
-```
-La opción `-a` nos muestra todos los contenedores.
+La opción `-all` nos muestra todos los contenedores.
 
 La instrucción anterior nos muestra el id del contenedor, la imagen con el que generamos el
 contenedor, el comando actual y otras columnas.
 
 Para ver solo el id de dichos procesos utilizamos 
-```
-$ docker ps -aq
+```shell
+$ docker ps --all --quiet
 ```
 Ahora, para borrar todos, utilizaremos la siguiente función con argumento el comando anterior.
-```bash
-$ docker rm $(docker ps -aq)
+```shell
+$ docker rm $(docker ps --all --quiet)
 ```
-La instrucción `rm` remueve los contenedores.
+El subcomando `docker rm` remueve los contenedores.
 
-Ya habiendo realizado esto, puedes volver a abrir el contenedor en vscode y estará resuelto el
-problema: nuestro directorio de trabajo será **/workdir**
+Ya habiendo realizado esto, puedes volver a abrir el contenedor en VS Code y estará resuelto el
+problema: nuestro directorio de trabajo será `/workdir/`

--- a/_posts/2022-03-08-devcontainer_workdir.md
+++ b/_posts/2022-03-08-devcontainer_workdir.md
@@ -10,9 +10,9 @@ Cuando se tienen errores del tipo un cierto archivo no se encuentra en
 ```
 Entonces dentro de **.devcontainer/devcontainer.json** se tiene que agregar:
 ```bash
-$ "workspaceMount": "source=${localWorkspaceFolder},target=/workdir,type=bind",
+"workspaceMount": "source=${localWorkspaceFolder},target=/workdir,type=bind",
 
-$ "workspaceFolder": "/workdir"
+"workspaceFolder": "/workdir"
 ```
 Ahora, se tienen que borrar los contenedores porque puede que vscode los vuelva a utilizar al
 reconstruir el contenedor, así que borraremos dichos contenedores desde una terminal fuera de
@@ -22,14 +22,20 @@ Primero se ven los procesos con
 ```bash
 $ docker ps -a
 ```
-Para verl el id de dichos procesos en docker (contenedores) utilizamos 
+La opción -a nos muestra todos los contenedores.
+
+La instrucción anterior nos muestra el id del contenedor, la imagen con el que se generó el
+contenedor, el comando actual y otras columnas.
+
+Para ver solo el id de dichos procesos utilizamos 
 ```bash
 $ docker ps -aq
 ```
-Ahora, para borrar todos, podemos utilizar la siguiente función con argumento otra función (la cual
-despliega todos los ids)
+Ahora, para borrar todos, podemos utilizar la siguiente función con argumento el comando anterior.
 ```bash
 $ docker rm $(docker ps -aq)
 ```
+El comando rm remueve los contenedores.
+
 Ya habiendo realizado esto, puedes volcer a abrir el contenedor en vscode y tendría que ya estar
 resuelto el problema, estando automaticamente en **/workdir**

--- a/_posts/2022-03-08-devcontainer_workdir.md
+++ b/_posts/2022-03-08-devcontainer_workdir.md
@@ -6,7 +6,7 @@ tags: equipo
 ---
 
 Cuando tengamos errores del tipo _missing file_ es probable que nuestra carpeta de trabajo y nuestra
-carpeta local no estén vinculadas. Para vincularlas tendremos que modificar el archivo
+carpeta local no estén vinculadas. Para vincular las carpetas tendremos que modificar el archivo
 `.devcontainer/devcontainer.json`.
 
 ```
@@ -22,36 +22,37 @@ Dentro de `.devcontainer/devcontainer.json` agregaremos:
 ```
 
 Con la opción `workspaceMount` le decimos al VS Code que vincule nuestro directorio local en la
-carpeta workdir. Y con la opción `workspaceFolder` definimos la carpeta de trabajo.
+carpeta `/workdir/`. Y con la opción `workspaceFolder` definimos la carpeta de trabajo.
 
-Ahora tenemos que borrar los contenedores porque puede que vscode los vuelva a utilizar al
+Ahora tenemos que borrar los contenedores porque puede ser que VS Code los vuelva a utilizar al
 reconstruir el contenedor. Así que borraremos dichos contenedores desde una terminal fuera de
 VS Code.
 
-Primero veremos los procesos con
+Primero veremos los procesos con:
 
 ```shell
-$ docker ps -all
+docker ps --all
 ```
 
-La opción `-all` nos muestra todos los contenedores.
+La opción `--all` nos muestra todos los contenedores.
 
-La instrucción anterior nos muestra el id del contenedor, la imagen con el que generamos el
+La instrucción anterior nos muestra el _id_ del contenedor, la imagen con el que generamos el
 contenedor, el comando actual y otras columnas.
 
-Para ver solo el id de dichos procesos utilizamos 
+Para ver sólo el _id_ de dichos contenedores utilizamos:
 
 ```shell
-$ docker ps --all --quiet
+docker ps --all --quiet
 ```
 
-Ahora, para borrar todos, utilizaremos la siguiente función con argumento el comando anterior.
+Ahora, para borrar todos los contenedores, utilizaremos la siguiente función con el comando anterior
+como argumento.
 
 ```shell
-$ docker rm $(docker ps --all --quiet)
+docker rm $(docker ps --all --quiet)
 ```
 
 El subcomando `docker rm` remueve los contenedores.
 
-Ya habiendo realizado esto, puedes volver a abrir el contenedor en VS Code y estará resuelto el
+Ya habiendo realizado esto, podemos volver a abrir el contenedor en VS Code y estará resuelto el
 problema: nuestro directorio de trabajo será `/workdir/`

--- a/_posts/2022-03-08-devcontainer_workdir.md
+++ b/_posts/2022-03-08-devcontainer_workdir.md
@@ -62,5 +62,5 @@ docker rm $(docker ps --all --quiet)
 El subcomando `docker rm` remueve los contenedores.
 
 Ya habiendo realizado esto, podemos volver a abrir el contenedor en VS Code y estará resuelto el
-problema: nuestro directorio de trabajo será `/workdir/`
+problema: nuestro directorio de trabajo será `/workdir/`.
 

--- a/_posts/2022-03-08-devcontainer_workdir.md
+++ b/_posts/2022-03-08-devcontainer_workdir.md
@@ -1,0 +1,35 @@
+---
+layout: post
+title: Devcontainer and workdir
+author: Francisco Alejandro Padilla Gomez
+tags: equipo
+---
+Cuando se tienen errores del tipo un cierto archivo no se encuentra en
+```bash
+/workspaces/sub-folder
+```
+Entonces dentro de **.devcontainer/devcontainer.json** se tiene que agregar:
+```bash
+$ "workspaceMount": "source=${localWorkspaceFolder},target=/workdir,type=bind",
+
+$ "workspaceFolder": "/workdir"
+```
+Ahora, se tienen que borrar los contenedores porque puede que vscode los vuelva a utilizar al
+reconstruir el contenedor, así que borraremos dichos contenedores desde una terminal fuera de
+vscode.
+
+Primero se ven los procesos con
+```bash
+$ docker ps -a
+```
+Para verl el id de dichos procesos en docker (contenedores) utilizamos 
+```bash
+$ docker ps -aq
+```
+Ahora, para borrar todos, podemos utilizar la siguiente función con argumento otra función (la cual
+despliega todos los ids)
+```bash
+$ docker rm $(docker ps -aq)
+```
+Ya habiendo realizado esto, puedes volcer a abrir el contenedor en vscode y tendría que ya estar
+resuelto el problema, estando automaticamente en **/workdir**


### PR DESCRIPTION
En los Dockerfile s de los repos clase 1 a veces usamos:

`Dockerfile`:
```
COPY . /workdir
```

o algo similar. Lo anterior nos impide usar :vs_code: de la misma manera que comúnmente lo usamos con los repos de clase 3. Para resolver este inconveniente, debemos agragar las siguientes líneas a nuestro archivo de configuración de :vs_code: Remote Development: Containers:

`.devcontainer/devcontainer.json`:

```json
"workspaceMount": "source=${localWorkspaceFolder},target=/workdir,type=bind",
"workspaceFolder": "/workdir"
```

El inconveniente al que me refiero es que hay dos copias del código adentro del contenedor generado por :vs_code: o que cuando haces modificaciones dentro del contenedor generado por :vs_code:, los cambios no persisten localmente cuando sales del contenedor.

---

Tres ingredientes para la revisión de la prosa:

- [ ] Oraciones preferentemente <25 palabras (estrictamente <30 palabras)
- [ ] Concordancia entre sujeto y verbo
- [ ] Voz activa